### PR TITLE
Add types to asset modules

### DIFF
--- a/src/Blog.tsx
+++ b/src/Blog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "./router";
 import { Breadcrumb, Time, useTitle } from "./utils";
-import metadata from "./blog/metadata.yml";
+import metadata from "~blog/metadata.yml";
 
 export const Blog = () => {
   useTitle("ybiquitous blog");
@@ -18,14 +18,16 @@ export const Blog = () => {
         <h2 style={{ margin: "var(--space) 0", fontSize: "1.5rem" }}>Recent posts</h2>
 
         <ul style={{ listStyle: "none", padding: "0" }}>
-          {metadata.map(({ id, title, published }: any) => (
-            <li key={id}>
-              <Link href={`/blog/${id}`} style={{ marginRight: "1em" }}>
-                {title}
-              </Link>
-              <Time date={published} />
-            </li>
-          ))}
+          {metadata
+            .filter(({ published }) => published != null)
+            .map(({ id, title, published }) => (
+              <li key={id}>
+                <Link href={`/blog/${id}`} style={{ marginRight: "1em" }}>
+                  {title}
+                </Link>
+                <Time date={published as Date} />
+              </li>
+            ))}
         </ul>
       </main>
     </>

--- a/src/BlogPost.tsx
+++ b/src/BlogPost.tsx
@@ -3,10 +3,7 @@ import { Link } from "./router";
 import { Breadcrumb, Time, useTitle } from "./utils";
 import "./BlogPost.css";
 
-interface Props {
-  title: string;
-  published: Date;
-  modified: Date | null;
+interface Props extends BlogMetadata {
   content: string;
 }
 
@@ -25,9 +22,11 @@ export const BlogPost = ({ title, published, modified, content }: Props) => {
 
       <main>
         <div className="blog-dates">
-          <div>
-            Published on <Time date={published} style={dateStyle} />
-          </div>
+          {published && (
+            <div>
+              Published on <Time date={published} style={dateStyle} />
+            </div>
+          )}
           {modified && (
             <div>
               Modified on <Time date={modified} style={dateStyle} />

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -5,7 +5,7 @@ import { faGithub, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { faAngleRight, faImages, faBlog } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "./router";
 import { Time, useTitle } from "./utils";
-import slidesMetadata from "./slides/metadata.yml";
+import slidesMetadata from "~slides/metadata.yml";
 import "./Home.css";
 
 const IconLink = ({ href, icon }: { href: string; icon: IconProp }) => {
@@ -76,7 +76,7 @@ const Slides = () => {
         aria-labelledby="menu-slides-button"
         aria-hidden={!expanded}
       >
-        {slidesMetadata.map(({ id, title, date }: any) => (
+        {slidesMetadata.map(({ id, title, date }) => (
           <li key={id} role="none">
             <FontAwesomeIcon icon={faAngleRight} fixedWidth />
             <a href={`/slides/${id}`} className="menu-link" role="menuitem">

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,17 +2,15 @@ import React from "react";
 import { Home } from "./Home";
 import { Blog } from "./Blog";
 import { BlogPost } from "./BlogPost";
-import blogMetadata from "./blog/metadata.yml";
+import blogMetadata from "~blog/metadata.yml";
 import blogStartBlog from "./blog/start-blog.md";
 import { NotFound } from "./NotFound";
 import { Routes } from "./router";
 
 const blogRoutes = blogMetadata.reduce(
-  (newRoutes: Routes, { id, title, published, modified }: any) => ({
+  (newRoutes: Routes, meta) => ({
     ...newRoutes,
-    [`/blog/${id}`]: () => (
-      <BlogPost title={title} published={published} modified={modified} content={blogStartBlog} />
-    ),
+    [`/blog/${meta.id}`]: () => <BlogPost {...meta} content={blogStartBlog} />,
   }),
   {}
 );

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,2 +1,4 @@
-declare module "*.md";
-declare module "*.yml";
+declare module "*.md" {
+  const content: string;
+  export default content;
+}

--- a/src/types/blog.d.ts
+++ b/src/types/blog.d.ts
@@ -1,0 +1,11 @@
+interface BlogMetadata {
+  id: string;
+  title: string;
+  published: Date | null;
+  modified: Date | null;
+}
+
+declare module "~blog/metadata.yml" {
+  const metadata: BlogMetadata[];
+  export default metadata;
+}

--- a/src/types/slide.d.ts
+++ b/src/types/slide.d.ts
@@ -1,0 +1,10 @@
+interface SlideMetadata {
+  id: string;
+  title: string;
+  date: Date;
+}
+
+declare module "~slides/metadata.yml" {
+  const metadata: SlideMetadata[];
+  export default metadata;
+}


### PR DESCRIPTION
Why?
----

To avoid using the `any` type. Because it skips any type-checking.

How?
----

Parcel supports the ["Tilde Paths"](https://parceljs.org/module_resolution.html#~-tilde-paths).
For example, `~/foo` resolves `foo` relative to the entry root.

And TypeScript can add types to module.
(see https://www.typescriptlang.org/docs/handbook/modules.html)

This 2 module resolution mechanisms can resolve the problem.