### PR TITLE
Use `type` instead of `interface` for TypeScript code

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
       "react/jsx-key": "warn",
       "react/jsx-no-target-blank": "warn",
       "react/no-array-index-key": "warn",
+      "@typescript-eslint/consistent-type-definitions": [
+        "error",
+        "type"
+      ],
       "@typescript-eslint/explicit-function-return-type": "warn"
     },
     "overrides": [

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -22,9 +22,9 @@ const scrollToAnchor = (target: Element) => {
   }
 };
 
-interface Props extends BlogMetadata {
+type Props = BlogMetadata & {
   content: string;
-}
+};
 
 export const BlogPost = ({ title, published, lastUpdated, author, content }: Props) => {
   useTitle(title, "Blog");

--- a/src/router/Link.tsx
+++ b/src/router/Link.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-interface Props {
+type Props = {
   href: string;
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
-}
+};
 
 export const Link = ({ href, children, className, style }: Props) => {
   return (

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-export interface Routes {
+export type Routes = {
   [key: string]: () => React.ReactElement;
-}
+};
 
-interface Props {
+type Props = {
   routes: Routes;
   currentPath: string;
-}
+};
 
 export const Router = ({ routes, currentPath }: Props) => {
   return (routes[currentPath] || routes["*"])();

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,9 +6,9 @@ import { blogs } from "./blog/index";
 import { Slides } from "./pages/Slides";
 import { NotFound } from "./pages/NotFound";
 
-interface Routes {
+type Routes = {
   [key: string]: () => JSX.Element;
-}
+};
 
 const blogRoutes: Routes = blogs.reduce(
   (newRoutes, blog) => ({

--- a/src/types/blog.d.ts
+++ b/src/types/blog.d.ts
@@ -1,10 +1,10 @@
-interface BlogMetadata {
+type BlogMetadata = {
   id: string;
   title: string;
   published: Date | null;
   lastUpdated: Date | null;
   author: string;
-}
+};
 
 declare module "~blog/metadata.yml" {
   const metadata: BlogMetadata[];

--- a/src/types/slide.d.ts
+++ b/src/types/slide.d.ts
@@ -1,8 +1,8 @@
-interface SlideMetadata {
+type SlideMetadata = {
   id: string;
   title: string;
   date: Date;
-}
+};
 
 declare module "~slides/metadata.yml" {
   const metadata: SlideMetadata[];

--- a/src/utils/Time.tsx
+++ b/src/utils/Time.tsx
@@ -7,10 +7,10 @@ const dateFormats = Object.freeze({
   day: "numeric",
 });
 
-interface Props {
+type Props = {
   date: Date;
   style?: React.CSSProperties;
-}
+};
 
 export const Time = ({ date, style }: Props) => {
   return (


### PR DESCRIPTION
This aims to enforce a consistency.
The [@typescript-eslint/consistent-type-definitions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-definitions.md) ESLint rule can help this.