### PR TITLE
Fix `set-env` on Actions

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           nvm install --latest-npm --no-progress
-          echo "::set-env name=PATH::${NVM_BIN}:${PATH}"
+          echo "PATH=${NVM_BIN}:${PATH}" >> $GITHUB_ENV
         shell: bash --login {0}
       - run: npx install-peerdeps eslint-config-ybiquitous
       - run: npx eslint .

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           nvm install --latest-npm --no-progress
-          echo "::set-env name=PATH::${NVM_BIN}:${PATH}"
+          echo "PATH=${NVM_BIN}:${PATH}" >> $GITHUB_ENV
         shell: bash --login {0}
       - run: npm install stylelint stylelint-config-standard stylelint-a11y stylelint-high-performance-animation
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           nvm install --latest-npm --no-progress
-          echo "::set-env name=PATH::${NVM_BIN}:${PATH}"
+          echo "PATH=${NVM_BIN}:${PATH}" >> $GITHUB_ENV
         shell: bash --login {0}
       - run: npm ci
       - run: npm run lint:types


### PR DESCRIPTION
`set-env` has been removed. See below:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/