### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15350,9 +15350,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
       "dev": true,
       "requires": {
         "clipboard": "^2.0.0"


### PR DESCRIPTION
### Updated (1)

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [prismjs](https://npm.im/prismjs) | `1.20.0` → `1.23.0` | [github](https://github.com/PrismJS/prism) | **[Moderate]** Regular Expression Denial of Service ([ref](https://npmjs.com/advisories/1638)) |

***

This pull request is created by [npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action). The used npm version is **6.14.11**.