### PR TITLE
Bump highlight.js from 10.7.2 to 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,16 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
-      "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-brands-svg-icons": "^5.15.3",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
-        "highlight.js": "^10.7.2",
+        "highlight.js": "^11.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@types/highlight.js": "^10.1.0",
         "@types/marked": "^2.0.3",
         "@types/node": "^15.6.1",
         "@types/parcel-bundler": "^1.12.3",
@@ -2746,15 +2743,6 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "node_modules/@types/highlight.js": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-10.1.0.tgz",
-      "integrity": "sha512-77hF2dGBsOgnvZll1vymYiNUtqJ8cJfXPD6GG/2M0aLRc29PkvB7Au6sIDjIEFcSICBhCh2+Pyq6WSRS7LUm6A==",
-      "dev": true,
-      "dependencies": {
-        "highlight.js": "*"
       }
     },
     "node_modules/@types/marked": {
@@ -7639,11 +7627,11 @@
       "dev": true
     },
     "node_modules/highlight.js": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
-      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -17133,7 +17121,7 @@
       "version": "0.0.1",
       "dev": true,
       "peerDependencies": {
-        "highlight.js": "10.x",
+        "highlight.js": "11.x",
         "marked": "2.x",
         "parcel-bundler": "1.x"
       }
@@ -19747,15 +19735,6 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "@types/highlight.js": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-10.1.0.tgz",
-      "integrity": "sha512-77hF2dGBsOgnvZll1vymYiNUtqJ8cJfXPD6GG/2M0aLRc29PkvB7Au6sIDjIEFcSICBhCh2+Pyq6WSRS7LUm6A==",
-      "dev": true,
-      "requires": {
-        "highlight.js": "*"
       }
     },
     "@types/marked": {
@@ -23757,9 +23736,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
-      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
+      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,11 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "highlight.js": "^10.7.2",
+    "highlight.js": "^11.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@types/highlight.js": "^10.1.0",
     "@types/marked": "^2.0.3",
     "@types/node": "^15.6.1",
     "@types/parcel-bundler": "^1.12.3",

--- a/src/parcel/plugin-markdown/asset.js
+++ b/src/parcel/plugin-markdown/asset.js
@@ -23,7 +23,7 @@ class MarkdownAsset extends Asset {
       breaks: true,
       highlight(code, lang) {
         return typeof lang === "string" && lang.length > 0 // eslint-disable-line @typescript-eslint/no-unsafe-return
-          ? highlight(code, { language: lang }).value // eslint-disable-line @typescript-eslint/no-unsafe-member-access @typescript-eslint/no-unsafe-call
+          ? highlight(code, { language: lang }).value // eslint-disable-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
           : code;
       },
       renderer: new MyRenderer(),

--- a/src/parcel/plugin-markdown/asset.js
+++ b/src/parcel/plugin-markdown/asset.js
@@ -22,8 +22,8 @@ class MarkdownAsset extends Asset {
     return marked(this.contents, {
       breaks: true,
       highlight(code, lang) {
-        return typeof lang === "string" && lang.length > 0
-          ? highlight(code, { language: lang }).value
+        return typeof lang === "string" && lang.length > 0 // eslint-disable-line @typescript-eslint/no-unsafe-return
+          ? highlight(code, { language: lang }).value // eslint-disable-line @typescript-eslint/no-unsafe-member-access @typescript-eslint/no-unsafe-call
           : code;
       },
       renderer: new MyRenderer(),

--- a/src/parcel/plugin-markdown/asset.js
+++ b/src/parcel/plugin-markdown/asset.js
@@ -1,4 +1,4 @@
-const hljs = require("highlight.js");
+const { highlight } = require("highlight.js");
 const marked = require("marked");
 const { Asset } = require("parcel-bundler");
 
@@ -23,7 +23,7 @@ class MarkdownAsset extends Asset {
       breaks: true,
       highlight(code, lang) {
         return typeof lang === "string" && lang.length > 0
-          ? hljs.highlight(code, { language: lang }).value
+          ? highlight(code, { language: lang }).value
           : code;
       },
       renderer: new MyRenderer(),

--- a/src/parcel/plugin-markdown/package.json
+++ b/src/parcel/plugin-markdown/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "peerDependencies": {
-    "highlight.js": "10.x",
+    "highlight.js": "11.x",
     "marked": "2.x",
     "parcel-bundler": "1.x"
   },


### PR DESCRIPTION
- `@types/highlight.js` is no longer necessary.
- The breaking changes don’t affect.

See also:
- https://github.com/highlightjs/highlight.js/blob/11.0.1/VERSION_11_UPGRADE.md