### PR TITLE
`npm run dev` -> `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm ci
 Start a development server on localhost.
 
 ```sh
-npm run dev
+npm start
 ```
 
 ### Build

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "parcel src/index.html",
+    "start": "parcel src/index.html",
     "build:parcel": "parcel build src/index.html --no-autoinstall --no-cache --no-source-maps",
     "build:slide": "rm -rf dist/slides && mkdir -p dist/slides && cp -R src/slides-build/* dist/slides/",
     "build": "npm-run-all --print-label --parallel build:*",


### PR DESCRIPTION
`npm start` is more common.