### PR TITLE
Use `compact` formatter for ESLint

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           node-version: "16.x"
       - run: npm install eslint-config-ybiquitous @typescript-eslint/eslint-plugin
-      - run: npx eslint .
+      - run: npx eslint . --format=compact


### PR DESCRIPTION
`eslint-compact.json` has a simpler pattern than `eslint-stylish.json`:

- https://github.com/actions/setup-node/blob/5c355be17065acf11598c7a9bb47112fbcf2bbdc/.github/eslint-compact.json
- https://github.com/actions/setup-node/blob/5c355be17065acf11598c7a9bb47112fbcf2bbdc/.github/eslint-stylish.json