### PR TITLE
Revert "Use `compact` formatter for ESLint"

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           node-version: "16.x"
       - run: npm install eslint-config-ybiquitous @typescript-eslint/eslint-plugin
-      - run: npx eslint . --format=compact
+      - run: npx eslint .


### PR DESCRIPTION
Reverts ybiquitous/homepage#506

No differences. Should prefer default.

Ref: https://github.com/ybiquitous/homepage/actions/runs/951610362