### PR TITLE
Use "←→" instead of "«»" for prev/next

### DIFF
--- a/src/pages/BlogPost.module.css
+++ b/src/pages/BlogPost.module.css
@@ -171,7 +171,7 @@
     justify-content: start;
 
     &::before {
-      content: "«";
+      content: "←";
       margin-right: 0.5em;
     }
   }
@@ -180,7 +180,7 @@
     justify-content: end;
 
     &::after {
-      content: "»";
+      content: "→";
       margin-left: 0.5em;
     }
   }


### PR DESCRIPTION
`«»` is used for quotation in some languages.