### PR TITLE
Fix 404 error on slide pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "start": "webpack serve --mode=development --node-env=development",
     "build:webpack": "webpack build --mode=production",
-    "build:slide": "rm -rf dist/slides && mkdir -p dist/slides && cp -R src/slides-build/* dist/slides/",
-    "build": "npm-run-all --print-label --parallel build:*",
+    "build:slides": "rm -rf dist/slides && mkdir -p dist/slides && cp -R src/slides-build/* dist/slides/",
+    "build": "npm-run-all --print-label build:webpack build:slides",
     "postbuild": "cp -v _redirects dist/",
     "static": "npm run build && npx http-server ./dist",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",


### PR DESCRIPTION
The cause is that `output.clean: true` is set in `webpack.config.js`:
https://github.com/ybiquitous/homepage/blob/cb934e07770394fd9fd25ca50e99d2335f5f7e93/webpack.config.js#L30

This bug fix changes `npm run build` from parallel to series.

---

<img width="918" alt="image" src="https://user-images.githubusercontent.com/473530/124681497-9d300d00-df03-11eb-9936-5b0fddb9d353.png">

https://ybiquitous.me/slides/website-performance