### PR TITLE
Refactor the use of actions/setup-node

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "${{ steps.nvm.outputs.nvmrc }}"
       - run: npm install eslint-config-ybiquitous @typescript-eslint/eslint-plugin
       - run: npx eslint .

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -12,7 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
       - uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvm.outputs.nvmrc }}"
       # https://github.com/actions/toolkit/blob/2f164000dcd42fb08287824a3bc3030dbed33687/docs/commands.md#problem-matchers
       # https://gist.github.com/ybiquitous/184a337662bfcafdd3d227253f9401ff
       - name: Set up Problem Matchers for stylelint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          nvm install --latest-npm --no-progress
-          echo "PATH=${NVM_BIN}:${PATH}" >> $GITHUB_ENV
-        shell: bash --login {0}
+      - run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        id: nvm
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "${{ steps.nvm.outputs.nvmrc }}"
       - run: npm ci
-      - name: Set up Problem Matchers for tsc
-        run: |
-          curl -fLO "https://raw.githubusercontent.com/actions/setup-node/5c355be17065acf11598c7a9bb47112fbcf2bbdc/.github/tsc.json"
-          mv tsc.json "${HOME}/tsc.json"
-          echo "::add-matcher::${HOME}/tsc.json"
-      - run: npm run lint:types
-      - run: npm run lint
+      - run: npm run lint-ci
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postbuild": "cp -v _redirects dist/",
     "static": "npm run build && npx http-server ./dist",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
+    "lint-ci": "npm-run-all --silent --parallel lint:* prettier:check",
     "lint": "npm-run-all --print-label --parallel lint:* prettier:check",
     "lint:md": "remark .",
     "lint:md:fix": "remark . --output",

--- a/src/Link.jsx
+++ b/src/Link.jsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 /**
  * @typedef {Object} Props

--- a/src/Link.jsx
+++ b/src/Link.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 /**
  * @typedef {Object} Props


### PR DESCRIPTION
- Set `.nvmrc` value to `with.node-version`
  See <https://github.com/actions/setup-node/issues/32#issuecomment-539794249>
- Add `npm run lint-ci` to use "Problem Matchers" of actions/setup-node