### PR TITLE
Adjust `.icon-link` CSS on Dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -119,7 +119,7 @@ details {
 
     /* https://github.com/remarkjs/remark-autolink-headings */
     .icon-link {
-      @apply before:content-['#'] ml-4 text-gray-300;
+      @apply before:content-['#'] ml-4 text-gray-300 dark:text-gray-600;
     }
 
     & > h1 a[aria-hidden] {


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="319" alt="image" src="https://user-images.githubusercontent.com/473530/132097014-18f8d5cc-eeba-4cc4-a198-f1b16d842851.png">|<img width="325" alt="image" src="https://user-images.githubusercontent.com/473530/132096970-c730fe51-b82e-46a3-ae83-aacee200a8bb.png">|
