### PR TITLE
Add remark as explicit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "mini-css-extract-plugin": "^2.2.2",
         "postcss": "^8.3.6",
         "postcss-loader": "^6.1.1",
+        "remark": "^13.0.0",
         "remark-autolink-headings": "^6.1.0",
         "remark-external-links": "^8.0.0",
         "remark-footnotes": "^3.0.0",
@@ -11999,6 +12000,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-preset-lint-recommended": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-5.0.0.tgz",
@@ -12143,19 +12157,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark/node_modules/remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-      "dev": true,
-      "dependencies": {
-        "mdast-util-from-markdown": "^0.8.0"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -23281,17 +23282,6 @@
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
-      },
-      "dependencies": {
-        "remark-parse": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-          "dev": true,
-          "requires": {
-            "mdast-util-from-markdown": "^0.8.0"
-          }
-        }
       }
     },
     "remark-autolink-headings": {
@@ -23972,6 +23962,15 @@
       "requires": {
         "mdast-comment-marker": "^1.0.0",
         "unified-message-control": "^3.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dev": true,
+      "requires": {
+        "mdast-util-from-markdown": "^0.8.0"
       }
     },
     "remark-preset-lint-recommended": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mini-css-extract-plugin": "^2.2.2",
     "postcss": "^8.3.6",
     "postcss-loader": "^6.1.1",
+    "remark": "^13.0.0",
     "remark-autolink-headings": "^6.1.0",
     "remark-external-links": "^8.0.0",
     "remark-footnotes": "^3.0.0",


### PR DESCRIPTION
`remark-loader` supports only [`remark@13`](https://github.com/remarkjs/remark/releases/tag/13.0.0), but [`remark@14`](https://github.com/remarkjs/remark/releases/tag/14.0.0) is the latest.

See also #594