### PR TITLE
Revert "Bump typescript from 4.4.4 to 4.5.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "remark-rehype": "^10.0.1",
         "style-loader": "^3.3.1",
         "tailwindcss": "^2.2.19",
-        "typescript": "^4.5.2",
+        "typescript": "^4.4.4",
         "unified": "^10.1.1",
         "unist-util-visit": "^4.1.0",
         "webpack": "^5.64.4",
@@ -15806,9 +15806,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -28900,9 +28900,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "remark-rehype": "^10.0.1",
     "style-loader": "^3.3.1",
     "tailwindcss": "^2.2.19",
-    "typescript": "^4.5.2",
+    "typescript": "^4.4.4",
     "unified": "^10.1.1",
     "unist-util-visit": "^4.1.0",
     "webpack": "^5.64.4",


### PR DESCRIPTION
Reverts ybiquitous/homepage#700

Because `npm run lint:types` hangs.