### PR TITLE
Bump `@fortawesome/*` packages from 6.0.0 to 6.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "homepage",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.3.0",
-        "@fortawesome/free-brands-svg-icons": "^6.0.0",
-        "@fortawesome/free-solid-svg-icons": "^6.0.0",
-        "@fortawesome/react-fontawesome": "^0.1.17",
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/free-brands-svg-icons": "^6.1.1",
+        "@fortawesome/free-solid-svg-icons": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.1.18",
         "core-js": "^3.21.1",
         "highlight.js": "^11.4.0",
         "react": "^17.0.2",
@@ -2359,59 +2358,59 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
-      "integrity": "sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz",
-      "integrity": "sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.0.0.tgz",
-      "integrity": "sha512-BIhsy2YeGuk8+KQwpqmyayQDWo1lvGMHsMIE+z5ApPRgV7T+zGhmNzYVoBT4IrJMC6ep5WpGrxoHX+IvNxHnkw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-mFbI/czjBZ+paUtw5NPr2IXjun5KAC8eFqh1hnxowjA4mMZxWz4GCIksq6j9ZSa6Uxj9JhjjDVEd77p2LN2Blg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.0.0.tgz",
-      "integrity": "sha512-o4FZ1XbndcgeWNb8Wh0y+Hgf73CjmyOQowUSaqQCtgIIdS+XliSBSOwCl330wER+I6CGYE96hT27bHBPmzX2Gg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
       "dependencies": {
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || >=1.3.0-beta1",
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.x"
       }
     },
@@ -18914,38 +18913,38 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
-      "integrity": "sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.1.tgz",
+      "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz",
-      "integrity": "sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
+      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       }
     },
     "@fortawesome/free-brands-svg-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.0.0.tgz",
-      "integrity": "sha512-BIhsy2YeGuk8+KQwpqmyayQDWo1lvGMHsMIE+z5ApPRgV7T+zGhmNzYVoBT4IrJMC6ep5WpGrxoHX+IvNxHnkw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-mFbI/czjBZ+paUtw5NPr2IXjun5KAC8eFqh1hnxowjA4mMZxWz4GCIksq6j9ZSa6Uxj9JhjjDVEd77p2LN2Blg==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.0.0.tgz",
-      "integrity": "sha512-o4FZ1XbndcgeWNb8Wh0y+Hgf73CjmyOQowUSaqQCtgIIdS+XliSBSOwCl330wER+I6CGYE96hT27bHBPmzX2Gg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.1.tgz",
+      "integrity": "sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.3.0"
+        "@fortawesome/fontawesome-common-types": "6.1.1"
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.17.tgz",
-      "integrity": "sha512-dX43Z5IvMaW7fwzU8farosYjKNGfRb2HB/DgjVBHeJZ/NSnuuaujPPx0YOdcAq+n3mqn70tyCde2HM1mqbhiuw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
+      "integrity": "sha512-RwLIB4TZw0M9gvy5u+TusAA0afbwM4JQIimNH/j3ygd6aIvYPQLqXMhC9ErY26J23rDPyDZldIfPq/HpTTJ/tQ==",
       "requires": {
         "prop-types": "^15.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "test:visual": "percy snapshot test/percy-snapshots.yml"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.3.0",
-    "@fortawesome/free-brands-svg-icons": "^6.0.0",
-    "@fortawesome/free-solid-svg-icons": "^6.0.0",
-    "@fortawesome/react-fontawesome": "^0.1.17",
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-brands-svg-icons": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@fortawesome/react-fontawesome": "^0.1.18",
     "core-js": "^3.21.1",
     "highlight.js": "^11.4.0",
     "react": "^17.0.2",

--- a/src/blog/2022/use-babel-macro-for-fontawesome-6.md
+++ b/src/blog/2022/use-babel-macro-for-fontawesome-6.md
@@ -111,7 +111,7 @@ nodePath.parentPath.replaceWith(importName)
 +FontAwesomeIcon icon={solid("cake")} />
 ```
 
-5. TypeScript環境では、型定義を追加する必要があった。[Issueが報告されていた](https://github.com/FortAwesome/Font-Awesome/issues/18616)ので、そのうち修正されるかもしれない。
+5. ~~TypeScript環境では、型定義を追加する必要があった。[Issueが報告されていた](https://github.com/FortAwesome/Font-Awesome/issues/18616)ので、そのうち修正されるかもしれない。~~ [6.1.1](https://github.com/FortAwesome/Font-Awesome/releases/tag/6.1.1) で修正された 🎉
 
 ```typescript
 declare module "@fortawesome/fontawesome-svg-core/import.macro" {

--- a/src/blog/metadata.json
+++ b/src/blog/metadata.json
@@ -187,7 +187,7 @@
     "slug": "2022/use-babel-macro-for-fontawesome-6",
     "title": "Font Awesome 6でBabelマクロを使う",
     "published": "2022-02-19T00:00:00.000Z",
-    "lastUpdated": "2022-02-19T00:00:00.000Z",
+    "lastUpdated": "2022-03-23T00:00:00.000Z",
     "author": "Masafumi Koba",
     "tags": ["babel", "react", "fontawesome"]
   },

--- a/src/types/fontawesome.d.ts
+++ b/src/types/fontawesome.d.ts
@@ -1,7 +1,0 @@
-declare module "@fortawesome/fontawesome-svg-core/import.macro" {
-  import type { IconName, IconProp } from "@fortawesome/fontawesome-svg-core";
-
-  export function brands(iconName: IconName): IconProp;
-  export function solid(iconName: IconName): IconProp;
-  export function reqular(iconName: IconName): IconProp;
-}


### PR DESCRIPTION
This also changes a part of the blog post `/blog/2022/use-babel-macro-for-fontawesome-6`.

See:
- https://github.com/FortAwesome/Font-Awesome/releases/tag/6.1.1
- https://github.com/FortAwesome/Font-Awesome/compare/6.0.0...6.1.1
- https://fontawesome.com/docs/changelog/