### PR TITLE
Ignore `@types/*` updates by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore