### PR TITLE
Change external links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.1.2",
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
         "@fortawesome/free-brands-svg-icons": "^6.1.2",
         "@fortawesome/free-solid-svg-icons": "^6.1.2",
@@ -38,7 +39,6 @@
         "postcss-loader": "^7.0.1",
         "prettier-plugin-tailwindcss": "^0.1.13",
         "rehype-autolink-headings": "^6.1.1",
-        "rehype-external-links": "^1.0.1",
         "rehype-highlight": "^5.0.2",
         "rehype-slug": "^5.0.1",
         "rehype-stringify": "^9.0.3",
@@ -2360,6 +2360,15 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
       "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -13481,36 +13490,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-external-links": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-1.0.1.tgz",
-      "integrity": "sha512-SrMMtIO2tPLWDfvibhECAn9cuEMW6Fi40ZVK2UQSPTnDEv3LraLzGVyKGb/vrDlUy4RCYTcmm0rq/ss9nPqrsw==",
-      "dev": true,
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "extend": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-external-links/node_modules/is-absolute-url": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/rehype-highlight": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-5.0.2.tgz",
@@ -19414,6 +19393,11 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
       "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA=="
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "6.1.2",
@@ -27469,28 +27453,6 @@
         "hast-util-is-element": "^2.0.0",
         "unified": "^10.0.0",
         "unist-util-visit": "^4.0.0"
-      }
-    },
-    "rehype-external-links": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-1.0.1.tgz",
-      "integrity": "sha512-SrMMtIO2tPLWDfvibhECAn9cuEMW6Fi40ZVK2UQSPTnDEv3LraLzGVyKGb/vrDlUy4RCYTcmm0rq/ss9nPqrsw==",
-      "dev": true,
-      "requires": {
-        "@types/hast": "^2.0.0",
-        "extend": "^3.0.0",
-        "is-absolute-url": "^4.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unified": "^10.0.0",
-        "unist-util-visit": "^4.0.0"
-      },
-      "dependencies": {
-        "is-absolute-url": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
-          "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
-          "dev": true
-        }
       }
     },
     "rehype-highlight": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:visual": "percy snapshot test/percy-snapshots.yml"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.1.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-brands-svg-icons": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",
@@ -59,7 +60,6 @@
     "postcss-loader": "^7.0.1",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "rehype-autolink-headings": "^6.1.1",
-    "rehype-external-links": "^1.0.1",
     "rehype-highlight": "^5.0.2",
     "rehype-slug": "^5.0.1",
     "rehype-stringify": "^9.0.3",

--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -1,27 +1,27 @@
-import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 /**
  * @param {{
  *   href: string,
  *   children: React.ReactNode,
- *   external?: boolean,
- *   showExternalIcon?: boolean,
- * } & React.AnchorHTMLAttributes<HTMLAnchorElement>} props
+ *   className?: string,
+ *   title?: string,
+ *   openNewWindow?: boolean,
+ *   noIcon?: boolean,
+ * }} props
  */
 export const Link = ({
   href,
   children,
   className,
   title,
-  external = href.startsWith("http"),
-  showExternalIcon = false,
+  openNewWindow = false,
+  noIcon = false,
 }) => {
   /** @type {React.MouseEventHandler} */
   const handleClick = useCallback(
     (event) => {
-      if (external) return;
+      if (openNewWindow || href.startsWith("http")) return;
 
       // normal behavior
       if (event.metaKey) return;
@@ -33,40 +33,20 @@ export const Link = ({
       window.history.pushState(state, "", href);
       window.dispatchEvent(new PopStateEvent("popstate", { state }));
     },
-    [href, external]
-  );
-
-  const [externalIconShown, setExternalIconShown] = useState(false);
-
-  const handleHover = useCallback(
-    (/** @type {boolean}*/ toggle) => {
-      if (external && showExternalIcon) {
-        setExternalIconShown(toggle);
-      }
-    },
-    [external, showExternalIcon]
+    [href]
   );
 
   /* eslint-disable react/jsx-no-target-blank -- False positive. */
   return (
     <a
       href={href}
-      className={className}
+      className={`${className ?? ""} ${noIcon ? "no-icon" : ""}`.trim()}
       title={title}
-      target={external ? "_blank" : undefined}
-      rel={external ? "noreferrer noopener" : undefined}
+      target={openNewWindow ? "_blank" : undefined}
+      rel={openNewWindow ? "noopener" : undefined}
       onClick={handleClick}
-      onMouseEnter={() => handleHover(true)}
-      onMouseLeave={() => handleHover(false)}
     >
       {children}
-      {Boolean(externalIconShown) && (
-        <FontAwesomeIcon
-          icon={solid("arrow-up-right-from-square")}
-          size="xs"
-          className="my-text-secondary"
-        />
-      )}
     </a>
   );
   /* eslint-enable react/jsx-no-target-blank */

--- a/src/components/Link.jsx
+++ b/src/components/Link.jsx
@@ -33,7 +33,7 @@ export const Link = ({
       window.history.pushState(state, "", href);
       window.dispatchEvent(new PopStateEvent("popstate", { state }));
     },
-    [href]
+    [href, openNewWindow]
   );
 
   /* eslint-disable react/jsx-no-target-blank -- False positive. */

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import "~@fortawesome/fontawesome-free/css/fontawesome.min.css";
+@import "~@fortawesome/fontawesome-free/css/solid.min.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -13,6 +16,18 @@
 
   details[open] > summary {
     @apply mb-2;
+  }
+
+  /* See https://fontawesome.com/v6/docs/web/add-icons/pseudo-elements */
+  a[href^="http"]:not(.no-icon)::after {
+    display: inline-block;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    font: var(--fa-font-solid);
+    font-size: 0.75em;
+    content: "\f08e";
+    margin: 0 0.25em 0 0.5em;
+    vertical-align: 0.125em;
   }
 }
 

--- a/src/pages/Home/Menu.jsx
+++ b/src/pages/Home/Menu.jsx
@@ -11,11 +11,7 @@ import { Link } from "../../components/Link";
  */
 export const Menu = ({ link, icon, content, subContent }) => (
   <div className="rounded border text-xl shadow transition-shadow hover:shadow-lg dark:hover:border-sky-500 dark:hover:text-sky-500">
-    <Link
-      className="flex items-center gap-4 px-5 pb-5 pt-6 !text-current"
-      href={link}
-      showExternalIcon
-    >
+    <Link className="flex items-center gap-4 px-5 pb-5 pt-6 !text-current" href={link} noIcon>
       <FontAwesomeIcon icon={icon} fixedWidth />
       <span>{content}</span>
       {subContent != null && <small className="my-text-secondary">{subContent}</small>}

--- a/src/pages/Slides.jsx
+++ b/src/pages/Slides.jsx
@@ -19,7 +19,7 @@ export const Slides = () => {
             .sort((a, b) => Date.parse(b.date) - Date.parse(a.date))
             .map(({ id, title, date }) => (
               <li key={id} className="py-10 first:pt-0 last:pb-0">
-                <Link href={`/slides/${id}`} className="block !text-current" external>
+                <Link href={`/slides/${id}`} className="block !text-current">
                   <div className="font-sans text-xl">{title}</div>
                   <Time date={new Date(date)} className="my-text-secondary" />
                 </Link>

--- a/src/remark/remark-loader.js
+++ b/src/remark/remark-loader.js
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import rehypeToc from "@jsdevtools/rehype-toc";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import rehypeExternalLinks from "rehype-external-links";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
@@ -49,7 +48,6 @@ export default async function remarkLoader(source) {
       },
     })
     .use(rehypeAutolinkHeadings, { behavior: "append" })
-    .use(rehypeExternalLinks)
     .use(rehypeHighlight)
     .use(rehypeStringify, { allowDangerousHtml: true })
     .process(source);


### PR DESCRIPTION
Close #923

[`rehype-external-links@2.0.0`](https://github.com/rehypejs/rehype-external-links/releases/tag/2.0.0) has changed the default behavior; not adding `target=_blank` by default. So, this pull request removes the needless package.

This pull request also changes the internal behavior for external links, considering accessibility:

- not opening a link in a new window/tab
- showing an external icon after a link

See also:

- [When to use target="_blank" | CSS-Tricks - CSS-Tricks](https://css-tricks.com/use-target_blank/)
- [CSS Pseudo-elements | Font Awesome Docs](https://fontawesome.com/v6/docs/web/add-icons/pseudo-elements)