### PR TITLE
Fix Stylelint failure on CI

### DIFF
--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -16,11 +16,5 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      # https://github.com/YozhikM/stylelint-a11y/pull/66
-      - run: |
-          npm install stylelint \
-                      stylelint-config-standard \
-                      'github:rsstdd/stylelint-a11y#chore/update-stylelint' \
-                      stylelint-high-performance-animation \
-                      stylelint-config-prettier
+      - run: npm run stylelint-install
       - run: npx stylelint "**/*.css" --formatter=github

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint": "eslint --cache --ext=js,jsx,cjs,mjs,ts,tsx .",
     "eslint:fix": "npm run eslint -- --fix",
     "test": "npm-run-all --parallel lint build",
-    "test:visual": "percy snapshot test/percy-snapshots.yml --base-url \"http://localhost:8080\""
+    "test:visual": "percy snapshot test/percy-snapshots.yml --base-url \"http://localhost:8080\"",
+    "stylelint-install": "npm install stylelint stylelint-config-standard stylelint-high-performance-animation @ronilaukkarinen/stylelint-a11y"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.2.1",
@@ -158,8 +159,7 @@
     ],
     "extends": [
       "stylelint-config-standard",
-      "stylelint-a11y/recommended",
-      "stylelint-config-prettier"
+      "@ronilaukkarinen/stylelint-a11y/recommended"
     ],
     "plugins": [
       "stylelint-high-performance-animation"
@@ -179,7 +179,6 @@
         }
       ],
       "declaration-block-no-duplicate-properties": true,
-      "declaration-block-trailing-semicolon": null,
       "declaration-property-value-disallowed-list": {
         "font-family": [
           "var(--font-family-serif)",


### PR DESCRIPTION
- `stylelint-a11y` is not maintained yet, so this change uses `@ronilaukkarinen/stylelint-a11y` instead.
  - https://www.npmjs.com/package/stylelint-a11y
  - https://www.npmjs.com/package/@ronilaukkarinen/stylelint-a11y
- `stylelint@15` has deprecated stylistic rules, so `stylelint-config-prettier` is no longer needed.
  - https://github.com/stylelint/stylelint/blob/4835d16/docs/migration-guide/to-15.md#deprecated-stylistic-rules
