### PR TITLE
Remove unneeded `remark-loader.cjs`

### DIFF
--- a/src/remark/remark-loader.cjs
+++ b/src/remark/remark-loader.cjs
@@ -1,5 +1,0 @@
-// @ts-nocheck
-// TODO: When Webpack supports ESM fully, this bridge module (CJS to ESM) will be no longer necessary.
-module.exports = function remarkLoader(...args) {
-  return import("./remark-loader.js").then((loader) => loader.default(...args));
-};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ const webpackConfig = {
       },
       {
         test: /\.md$/u,
-        use: [fileURLToPath(new URL("./src/remark/remark-loader.cjs", import.meta.url))],
+        use: [fileURLToPath(new URL("./src/remark/remark-loader.js", import.meta.url))],
       },
     ],
   },


### PR DESCRIPTION
Webpack can now read loaders written in ESM. So, bridging from CJS to ESM is no longer needed.
