### PR TITLE
Keep wording consistent between blog pages

### DIFF
--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -3,6 +3,7 @@ import { Link } from "../components/Link";
 import { Tags } from "../components/Tags";
 import { Time } from "../components/Time";
 import { useTitle } from "../hooks/useTitle";
+import { pluralize } from "../utils/pluralize";
 
 /**
  * @param {{
@@ -49,9 +50,9 @@ export const Blog = ({ posts, breadcrumbs }) => {
             ))}
         </ul>
 
-        <div className="my-text-secondary mt-12 text-center text-sm">{`Total ${posts.length} ${
-          posts.length === 1 ? "post" : "posts"
-        }`}</div>
+        <div className="my-text-secondary mt-12 text-sm">
+          {`Total ${posts.length} ${pluralize(posts.length, "post")}`}
+        </div>
       </main>
     </>
   );

--- a/src/pages/BlogTags.jsx
+++ b/src/pages/BlogTags.jsx
@@ -40,7 +40,7 @@ export const BlogTags = ({ postsByTag }) => {
               ))}
             </ul>
             <p className="my-text-secondary mt-8 text-sm">
-              {`${tagCount} ${pluralize(tagCount, "tag")} found.`}
+              {`Total ${tagCount} ${pluralize(tagCount, "tag")}`}
             </p>
           </>
         )}


### PR DESCRIPTION
This changes aims to keep wording consistent between the following pages:

- `/blog`
- `/blog/{year}`
- `/blog/tags`
- `/blog/tags/{tag}`

The reason to move "Total ..." from center to left is that I feel hard to find text in the center of a page.

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
