### PR TITLE
Refactor blog metadata generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "remark-rehype": "^11.1.0",
         "remark-stringify": "^11.0.0",
         "tailwindcss": "^3.4.1",
+        "to-vfile": "^8.0.0",
         "typescript": "^5.3.3",
         "unified": "^11.0.4",
         "unist-util-visit": "^5.0.0",
@@ -22914,6 +22915,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-vfile": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-8.0.0.tgz",
+      "integrity": "sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==",
+      "dev": true,
+      "dependencies": {
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "remark-rehype": "^11.1.0",
     "remark-stringify": "^11.0.0",
     "tailwindcss": "^3.4.1",
+    "to-vfile": "^8.0.0",
     "typescript": "^5.3.3",
     "unified": "^11.0.4",
     "unist-util-visit": "^5.0.0",

--- a/src/remark/metadata-generator.js
+++ b/src/remark/metadata-generator.js
@@ -13,12 +13,9 @@ import { unified } from "unified";
 import yaml from "yaml";
 /* eslint-enable import/no-extraneous-dependencies */
 
-/**
- * @typedef {import('unist').Node} Node
- * @typedef {import('vfile').VFile} VFile
- *
- * @type {() => (tree: Node, file: VFile) => void}
- */
+/** @typedef {import('unist').Node} Node */
+/** @typedef {import('vfile').VFile} VFile */
+/** @type {() => (tree: Node, file: VFile) => void} */
 function processMarkdown() {
   return (tree, file) => {
     parent(tree);

--- a/src/remark/metadata-generator.js
+++ b/src/remark/metadata-generator.js
@@ -1,60 +1,66 @@
 /* eslint-env node */
 /* eslint-disable import/no-extraneous-dependencies */
-import * as fs from "node:fs/promises";
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
 
 import { globSync } from "glob";
 import { literal, parent } from "mdast-util-assert";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkParse from "remark-parse";
 import remarkStringify from "remark-stringify";
+import { readSync } from "to-vfile";
 import { unified } from "unified";
 import yaml from "yaml";
 /* eslint-enable import/no-extraneous-dependencies */
 
 /**
- * @param {string} file
+ * @typedef {import('unist').Node} Node
+ * @typedef {import('vfile').VFile} VFile
+ *
+ * @type {() => (tree: Node, file: VFile) => void}
  */
-async function processFile(file) {
-  const content = await fs.readFile(file, "utf-8");
+function processMarkdown() {
+  return (tree, file) => {
+    parent(tree);
 
-  return new Promise((resolve, reject) => {
-    unified()
-      .use(remarkParse)
-      .use(remarkStringify)
-      .use(remarkFrontmatter, ["yaml"])
-      .use(() => (tree) => {
-        parent(tree);
+    const yamlNode = tree.children.find(({ type }) => type === "yaml");
+    if (yamlNode === undefined) {
+      file.fail(new Error(`No front matter in ${file.path}`));
+    }
+    literal(yamlNode);
 
-        const yamlNode = tree.children.find(({ type }) => type === "yaml");
-        if (yamlNode === undefined) {
-          reject(new Error(`No front matter in ${file}`));
-          return;
-        }
-        literal(yamlNode);
+    const h1 = tree.children.find((child) => child.type === "heading" && child.depth === 1);
+    if (h1 === undefined) {
+      file.fail(new Error(`No h1 in ${file.path}`));
+    }
+    parent(h1);
 
-        const h1 = tree.children.find((child) => child.type === "heading" && child.depth === 1);
-        if (h1 === undefined) {
-          reject(new Error(`No h1 in ${file}`));
-          return;
-        }
-        parent(h1);
+    const [h1Child] = h1.children;
+    literal(h1Child);
 
-        const [h1Child] = h1.children;
-        literal(h1Child);
+    /** @type {{ slug: string; title: string; tags?: string | string[]; }} */
+    const metadata = yaml.parse(yamlNode.value); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+    metadata.slug = file.path.replace(/\.md$/u, "").split("/").slice(-2).join("/");
+    metadata.title = h1Child.value;
+    metadata.tags = (metadata.tags?.toString() ?? "")
+      .split(/\s{0,10},\s{0,10}/u)
+      .filter((tag) => tag.trim().length > 0)
+      .sort((a, b) => a.localeCompare(b));
 
-        /** @type {{ slug: string; title: string; tags?: string | string[]; }} */
-        const metadata = yaml.parse(yamlNode.value); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-        metadata.slug = file.replace(/\.md$/u, "").split("/").slice(-2).join("/");
-        metadata.title = h1Child.value;
-        metadata.tags = (metadata.tags?.toString() ?? "")
-          .split(/\s{0,10},\s{0,10}/u)
-          .filter((tag) => tag.trim().length > 0)
-          .sort((a, b) => a.localeCompare(b));
+    file.data = metadata; // eslint-disable-line no-param-reassign
+  };
+}
 
-        resolve(metadata);
-      })
-      .process(content);
-  });
+/**
+ * @param {string} filePath
+ */
+async function processFile(filePath) {
+  return unified()
+    .use(remarkParse)
+    .use(remarkStringify)
+    .use(remarkFrontmatter, ["yaml"])
+    .use(processMarkdown)
+    .process(readSync(filePath));
 }
 
 /**
@@ -63,22 +69,22 @@ async function processFile(file) {
  */
 async function main(inputPattern = "", outputFile = "") {
   const files = globSync(inputPattern);
-  const list = await Promise.all(files.map(processFile));
+  const vFiles = await Promise.all(files.map(processFile));
+  const metadataList = vFiles.map((vFile) => vFile.data);
 
-  /**
-   * @typedef {{ published: string | null }} MetaEntry
-   * @type {(a: MetaEntry, b: MetaEntry) => number}
-   */
+  /** @typedef {import('vfile').Data} Data */
+  /** @type {(a: Data, b: Data) => number} */
   const byPublished = (a, b) => {
-    if (a.published === null || b.published === null) {
-      return 0;
-    }
-    return Date.parse(a.published) - Date.parse(b.published);
+    const aPublished = a["published"] ?? "1970-01-01T00:00:00.000Z";
+    const bPublished = b["published"] ?? "1970-01-01T00:00:00.000Z";
+    assert(typeof aPublished === "string");
+    assert(typeof bPublished === "string");
+    return Date.parse(aPublished) - Date.parse(bPublished);
   };
-  list.sort(byPublished);
+  metadataList.sort(byPublished);
 
-  const content = `export default ${JSON.stringify(list, null, 2)}`;
-  await fs.writeFile(outputFile, content);
+  const content = `export default ${JSON.stringify(metadataList, null, 2)}`;
+  await writeFile(outputFile, content, "utf-8");
 }
 
 main(process.argv[2], process.argv[3]);


### PR DESCRIPTION
This uses the unified.js API as much as possible, installing [`to-vfile`](https://www.npmjs.com/package/to-vfile).
Ref: https://unifiedjs.com/learn/guide/create-a-plugin/

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
