### PR TITLE
Jump to heading in blog posts

### DIFF
--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -51,6 +51,14 @@ export const BlogPost = ({
       generateCopyToClipboard(contentEl);
       replaceSpeakerdeck(contentEl);
       replaceTweet(contentEl);
+
+      // Scroll to heading when hash is present.
+      const hash = window.location.hash;
+      if (hash) {
+        const id = decodeURIComponent(hash.slice(1));
+        const el = document.querySelector(`[id="${id}"]`);
+        el?.scrollIntoView();
+      }
     }
   }, [slug, content, contentElement.current]); // eslint-disable-line react-hooks/exhaustive-deps -- Needed for DOM manipulations.
 

--- a/src/remark/remark-relative-link.js
+++ b/src/remark/remark-relative-link.js
@@ -4,9 +4,10 @@ import { visit } from "unist-util-visit"; // eslint-disable-line import/no-extra
 export default function remarkRelativeLink() {
   return (tree) => {
     visit(tree, "link", (link) => {
-      if (!link.url.startsWith("http")) {
-        link.url = link.url.replace(/\.md$/u, ""); // eslint-disable-line no-param-reassign
-      }
+      if (link.url.startsWith("http")) return;
+      if (!link.url.includes(".md")) return;
+
+      link.url = link.url.replace(/\.md/u, ""); // eslint-disable-line no-param-reassign
     });
   };
 }


### PR DESCRIPTION
This implements a feature to jump to a heading in a blog post page when the page URL includes a hash.

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
