### PR TITLE
Adjust footnotes CSS in blog

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -145,7 +145,11 @@
 
     /* https://github.com/remarkjs/remark-gfm */
     & > .footnotes {
-      @apply border-t pt-4;
+      @apply border-t pt-4 text-sm;
+
+      & p {
+        margin: 0;
+      }
     }
 
     /* https://github.com/JS-DevTools/rehype-toc */


### PR DESCRIPTION
<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->

Margins in the footnotes are too wide. For example:

<img width="843" alt="image" src="https://github.com/ybiquitous/homepage/assets/473530/eee5657e-179d-4818-872a-3b76feb88fc7">

https://ybiquitous.me/blog/2019/type-compatibility-in-typescript