### PR TITLE
Use `node:fs` glob library instead of `glob` npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "css-loader": "^7.1.2",
         "cssnano": "^7.0.1",
         "eslint-config-ybiquitous": "^20.0.0",
-        "glob": "^10.4.1",
         "html-webpack-plugin": "^5.6.0",
         "mdast-util-assert": "^5.0.0",
         "mini-css-extract-plugin": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "css-loader": "^7.1.2",
     "cssnano": "^7.0.1",
     "eslint-config-ybiquitous": "^20.0.0",
-    "glob": "^10.4.1",
     "html-webpack-plugin": "^5.6.0",
     "mdast-util-assert": "^5.0.0",
     "mini-css-extract-plugin": "^2.9.0",

--- a/src/remark/metadata-generator.js
+++ b/src/remark/metadata-generator.js
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import assert from "node:assert/strict";
+// @ts-expect-error -- TS2305: Module '"node:fs"' has no exported member 'globSync'.
+import { globSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import process from "node:process";
 
-import { globSync } from "glob";
 import { literal, parent } from "mdast-util-assert";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkParse from "remark-parse";
@@ -68,6 +69,7 @@ async function processFile(filePath) {
 async function main(inputPattern, outputFile) {
   const files = globSync(inputPattern);
   const vFiles = await Promise.all(files.map(processFile));
+  // @ts-expect-error -- TS7006: Parameter 'vFile' implicitly has an 'any' type.
   const metadataList = vFiles.map((vFile) => vFile.data);
 
   /** @typedef {import('vfile').Data} Data */

--- a/src/remark/metadata-generator.js
+++ b/src/remark/metadata-generator.js
@@ -67,9 +67,9 @@ async function processFile(filePath) {
  * @param {string} outputFile
  */
 async function main(inputPattern, outputFile) {
-  const files = globSync(inputPattern);
+  /** @type {string[]} */
+  const files = globSync(inputPattern); // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   const vFiles = await Promise.all(files.map(processFile));
-  // @ts-expect-error -- TS7006: Parameter 'vFile' implicitly has an 'any' type.
   const metadataList = vFiles.map((vFile) => vFile.data);
 
   /** @typedef {import('vfile').Data} Data */


### PR DESCRIPTION
Node.js v22 added an experimental API for glob. See:
https://nodejs.org/api/fs.html#fsglobsyncpattern-options

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
