### PR TITLE
Remove unnecessary Speaker Deck slide margin

### DIFF
--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -6,7 +6,6 @@ import { useTitle } from "../hooks/useTitle";
 import { Navi } from "./BlogPost/Navi";
 import { Times } from "./BlogPost/Times";
 import { generateCopyToClipboard } from "./BlogPost/generateCopyToClipboard";
-import { replaceSpeakerdeck } from "./BlogPost/replaceSpeakerdeck";
 import { replaceTweet } from "./BlogPost/replaceTweet";
 
 /**
@@ -49,7 +48,6 @@ export const BlogPost = ({
       }
 
       generateCopyToClipboard(contentEl);
-      replaceSpeakerdeck(contentEl);
       replaceTweet(contentEl);
 
       // Scroll to heading when hash is present.

--- a/src/pages/BlogPost/replaceSpeakerdeck.js
+++ b/src/pages/BlogPost/replaceSpeakerdeck.js
@@ -1,9 +1,0 @@
-/**
- * @param {HTMLElement} el
- * @returns {void}
- */
-export function replaceSpeakerdeck(el) {
-  for (const deck of el.querySelectorAll(".speakerdeck-iframe")) {
-    deck.parentElement?.replaceWith(deck);
-  }
-}


### PR DESCRIPTION
Speaker Deck's `<iframe>` is rendered under `<p>`, but this is not a problem for layout.

<img width="353" alt="image" src="https://github.com/ybiquitous/homepage/assets/473530/3a2d8dd9-21b8-4abe-a9d7-3d62339c9e8b">



<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
