### PR TITLE
Support GitHub Alerts for blog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "remark": "^15.0.1",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
+        "remark-github-blockquote-alert": "^1.2.1",
         "remark-parse": "^11.0.0",
         "remark-preset-ybiquitous": "^0.4.4",
         "remark-rehype": "^11.1.0",
@@ -15761,6 +15762,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-github-blockquote-alert": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/remark-github-blockquote-alert/-/remark-github-blockquote-alert-1.2.1.tgz",
+      "integrity": "sha512-qNf2mSAoZgh3Cl23/9Y1L7S4Kbf9NsdHvYK398ab/52yEsDPDU5I4cuTcgDRrdIX7Ltc6RK+KCLRtWkbFnL6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/remark-lint": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "remark": "^15.0.1",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
+    "remark-github-blockquote-alert": "^1.2.1",
     "remark-parse": "^11.0.0",
     "remark-preset-ybiquitous": "^0.4.4",
     "remark-rehype": "^11.1.0",

--- a/src/blog/2021/build-emacs-from-source.md
+++ b/src/blog/2021/build-emacs-from-source.md
@@ -1,6 +1,6 @@
 ---
 published: 2021-11-23T00:00:00.000Z
-lastUpdated: 2022-04-23T00:00:00.000Z
+lastUpdated: 2024-06-11T00:00:00.000Z
 author: Masafumi Koba
 tags: emacs
 ---
@@ -42,7 +42,8 @@ $ system_profiler SPSoftwareDataType | grep Version
 $ git fast-clone https://github.com/emacs-mirror/emacs.git
 ```
 
-Note: `git fast-clone` は[独自エイリアス](./git-partial-clone.md)であることに注意。
+> [!NOTE]
+> `git fast-clone` は[独自エイリアス](./git-partial-clone.md)であることに注意。
 
 ## ビルド準備
 
@@ -126,9 +127,13 @@ $ open ~/Applications/Emacs.app
 必要なライブラリが分からなくて最初は少しハマったが、以降は問題なくインストールできたし、今のところ問題なく動いている。
 （このブログもビルドしたEmacsで書いている）
 
-`NEWS` 眺めてると、[Emojiサポート](https://github.com/emacs-mirror/emacs/blob/2955d46c00430b38310d0fae968adea91e2bbc3d/etc/NEWS#L108)のセクションを見つけた。`C-x 8 e e` でEmoji選べるようになってる。便利。
+`NEWS` 眺めてると、[Emojiサポート](https://github.com/emacs-mirror/emacs/blob/2955d46c00430b38310d0fae968adea91e2bbc3d/etc/NEWS#L108)のセクションを見つけた。<kbd>C-x 8 e e</kbd>でEmoji選べるようになってる。便利。
 
 ![Emoji support on Emacs 29](../../images/emoji-support-on-emacs-29.png)
+
+> [!NOTE]
+> Emacs 29で公式にサポートされた🎉（[NEWS](https://github.com/emacs-mirror/emacs/blob/emacs-29.1/etc/NEWS#L884)）。
+> デフォルトのキープレフィックスは<kbd>C-x 8 e</kbd>。
 
 意外と簡単にビルドできたので、今後も定期的にソースからビルドするつもり。
 

--- a/src/blog/2021/build-emacs-from-source.md
+++ b/src/blog/2021/build-emacs-from-source.md
@@ -127,7 +127,7 @@ $ open ~/Applications/Emacs.app
 必要なライブラリが分からなくて最初は少しハマったが、以降は問題なくインストールできたし、今のところ問題なく動いている。
 （このブログもビルドしたEmacsで書いている）
 
-`NEWS` 眺めてると、[Emojiサポート](https://github.com/emacs-mirror/emacs/blob/2955d46c00430b38310d0fae968adea91e2bbc3d/etc/NEWS#L108)のセクションを見つけた。<kbd>C-x 8 e e</kbd>でEmoji選べるようになってる。便利。
+`NEWS` 眺めてると、[Emojiサポート](https://github.com/emacs-mirror/emacs/blob/2955d46c00430b38310d0fae968adea91e2bbc3d/etc/NEWS#L108)のセクションを見つけた。<kbd>C-x 8 e e</kbd>でEmojiを選べるようになってる。便利。
 
 ![Emoji support on Emacs 29](../../images/emoji-support-on-emacs-29.png)
 

--- a/src/blog/2024/look-up-in-dictionary-in-firefox-on-macos.md
+++ b/src/blog/2024/look-up-in-dictionary-in-firefox-on-macos.md
@@ -30,7 +30,7 @@ Safariは言わすもがなだが、macOSのChromeでは右クリックすると
 - [301451 - \[meta\] Gecko doesn't support Cmd-Ctrl-D lookup in Mac OS X Dictionary.app](https://bugzilla.mozilla.org/show_bug.cgi?id=301451)
 - [1116391 - Add "Look Up in Dictionary" context menu entry \[Mac OS X\]](https://bugzilla.mozilla.org/show_bug.cgi?id=1116391)
 
-最初のチケットは <kbd>Control</kbd>+<kbd>Command</kbd>+<kbd>D</kbd> ショートカットキーに対応したもので、クローズされている。
+最初のチケットは<kbd>Control</kbd>+<kbd>Command</kbd>+<kbd>D</kbd>ショートカットキーに対応したもので、クローズされている。
 ちなみに、そのショートカットキーのことはこのブログを書くまで知らなかった。[このページ](https://support.apple.com/en-us/HT201236)にmacOSショートカットキーの一覧が載っている。正直このショートカットキーは覚えにくく、押しにくい。
 
 2番目のチケットがまさに探していたもので、何と9年前にオープンされているがまだクローズされていない。やはりネイティブの人は辞書なんかしょっちゅう使わないので、優先順位が低いのだろうか。個人的にはなんとか実装してほしい。

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,9 @@
   }
 
   kbd {
-    @apply mx-1 rounded-lg border border-gray-200 px-1.5 py-1 text-xs;
+    @apply mx-1 rounded-lg border border-gray-200 px-1.5 py-0.5 text-xs;
+
+    box-shadow: inset 0 -1px 0 lightgray;
   }
 
   address {

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@
   }
 
   kbd {
-    @apply rounded-lg border border-gray-200 px-1.5 py-1 text-xs;
+    @apply mx-1 rounded-lg border border-gray-200 px-1.5 py-1 text-xs;
   }
 
   address {
@@ -170,6 +170,31 @@
 
       .toc-link {
         @apply ml-2 text-current hover:underline;
+      }
+    }
+
+    /* https://github.com/jaywcjlove/remark-github-blockquote-alert */
+    .markdown-alert {
+      @apply my-8 grid gap-2 rounded-md border-s-4 border-blue-500 bg-gray-200 p-4 text-sm dark:bg-gray-800;
+
+      & > .markdown-alert-title {
+        @apply flex items-center gap-2 font-semibold capitalize;
+
+        & > .octicon {
+          fill: currentcolor;
+        }
+      }
+
+      &.markdown-alert-note {
+        @apply border-blue-500;
+
+        & > .markdown-alert-title {
+          @apply text-blue-500;
+        }
+      }
+
+      & > p {
+        @apply m-0;
       }
     }
   }

--- a/src/remark/remark-loader.js
+++ b/src/remark/remark-loader.js
@@ -4,6 +4,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
+import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
@@ -24,6 +25,7 @@ export default async function remarkLoader(source) {
     .use(remarkRemoveH1)
     .use(remarkRelativeLink)
     .use(remarkGfm)
+    .use(remarkAlert)
     .use(remarkSpeakerdeck)
     .use(remarkTwitter)
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/src/remark/remark-loader.js
+++ b/src/remark/remark-loader.js
@@ -4,9 +4,9 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
-import { remarkAlert } from "remark-github-blockquote-alert";
 import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
+import { remarkAlert } from "remark-github-blockquote-alert"; // eslint-disable-line import/no-unresolved
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import { unified } from "unified";

--- a/test/percy-snapshots.yml
+++ b/test/percy-snapshots.yml
@@ -65,6 +65,13 @@
   execute: |
     document.querySelector('[title="Light"]').click();
 
+- name: Blog Post with GFM Alerts
+  url: /blog/2021/build-emacs-from-source
+  waitForTimeout: 5000
+  waitForSelector: ".markdown-alert"
+  execute: |
+    document.querySelector('[title="Light"]').click();
+
 - name: Slides
   url: /slides
   execute: |


### PR DESCRIPTION
Using this remark plugin: https://github.com/jaywcjlove/remark-github-blockquote-alert

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
