### PR TITLE
Adjust CSS in blog list page

### DIFF
--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -48,9 +48,9 @@ export const Blog = ({ posts, breadcrumbs }) => {
             .sort((a, b) => (b.published?.getTime() ?? 0) - (a.published?.getTime() ?? 0))
             .map(({ path, title: blogTitle, published, author, tags }) => (
               <li key={path} className="py-10 first:pt-0 last:pb-0">
-                <Link href={path} className="block !text-current">
+                <Link href={path} className="grid gap-2 !text-current">
                   <div className="text-xl">{blogTitle}</div>
-                  <div className="my-text-secondary flex flex-wrap gap-x-8">
+                  <div className="my-text-secondary flex flex-wrap gap-x-8 text-sm">
                     {published !== null && <Time date={published} />}
                     <address>{`by ${author}`}</address>
                   </div>


### PR DESCRIPTION
<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->

- Insert a gap between a blog title and date/author.
- Make a blog date/author font smaller.

<img width="392" alt="Screenshot 2024-06-19 at 22 10 48" src="https://github.com/ybiquitous/homepage/assets/473530/b029cf9b-3b3e-4ba6-94f0-9543eaec5548">

