### PR TITLE
Fix `dependabot-auto-merge` GHA workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   auto-merge:
     uses: ybiquitous/.github/.github/workflows/dependabot-auto-merge-reusable.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
This fixes the following failure:

```
The workflow is not valid. .github/workflows/dependabot-auto-merge.yml (Line: 8, Col: 3): Error calling workflow 'ybiquitous/.github/.github/workflows/dependabot-auto-merge-reusable.yml@main'. The nested job 'auto-merge' is requesting 'contents: write', but is only allowed 'contents: read'.
```

-- https://github.com/ybiquitous/homepage/actions/runs/10796010164

The original workflow's code:
https://github.com/ybiquitous/.github/blob/9b110db8f5d6acc3a6ef18c55946b0b931eb550e/.github/workflows/dependabot-auto-merge-reusable.yml#L21C5-L22C22

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
