### PR TITLE
Increase line height for easier tapping in blog TOC

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -170,8 +170,12 @@
         @apply list-none pl-2 pt-2;
       }
 
-      .toc-item::marker {
-        content: "»";
+      .toc-item {
+        @apply leading-10;
+
+        &::marker {
+          content: "»";
+        }
       }
 
       .toc-link {


### PR DESCRIPTION
Ref https://tailwindcss.com/docs/line-height

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
