### PR TITLE
Avoid Babel Macro for Font Awesome icons

### DIFF
--- a/src/components/CopyToClipboard.jsx
+++ b/src/components/CopyToClipboard.jsx
@@ -1,4 +1,4 @@
-import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
+import { faCheck, faCopy, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 
@@ -28,15 +28,15 @@ export const CopyToClipboard = ({ text }) => {
   };
 
   let style = "text-gray-300 hover:text-gray-500";
-  let icon = solid("copy");
+  let icon = faCopy;
   let message;
   if (state === SUCCEEDED) {
     style = "text-emerald-500";
-    icon = solid("check");
+    icon = faCheck;
     message = "Copied!";
   } else if (state === FAILED) {
     style = "text-red-500";
-    icon = solid("xmark");
+    icon = faXmark;
     message = "Failed to copy.";
   }
 

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,4 +1,4 @@
-import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
+import { faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 import { useMount } from "../hooks/useMount";
@@ -64,19 +64,13 @@ export const ThemeToggle = () => {
   return (
     <span>
       <button type="button" title="Light" onClick={() => handleClick(false)}>
-        <FontAwesomeIcon
-          icon={solid("sun")}
-          className={dark ? "text-slate-400" : "text-orange-400"}
-        />
+        <FontAwesomeIcon icon={faSun} className={dark ? "text-slate-400" : "text-orange-400"} />
       </button>
 
       <span className="mx-1 text-slate-200">|</span>
 
       <button type="button" title="Dark" onClick={() => handleClick(true)}>
-        <FontAwesomeIcon
-          icon={solid("moon")}
-          className={dark ? "text-yellow-400" : "text-slate-400"}
-        />
+        <FontAwesomeIcon icon={faMoon} className={dark ? "text-yellow-400" : "text-slate-400"} />
       </button>
     </span>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,5 @@
-import { faBlog, faGem, faImages } from "@fortawesome/free-solid-svg-icons";
 import { faGithub, faNpm, faTwitter } from "@fortawesome/free-brands-svg-icons";
+import { faBlog, faGem, faImages } from "@fortawesome/free-solid-svg-icons";
 import { Title } from "../components/Title";
 import { Menu } from "./Home/Menu";
 import { Profile } from "./Home/Profile";

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
-import { brands, solid } from "@fortawesome/fontawesome-svg-core/import.macro";
+import { faBlog, faGem, faImages } from "@fortawesome/free-solid-svg-icons";
+import { faGithub, faNpm, faTwitter } from "@fortawesome/free-brands-svg-icons";
 import { Title } from "../components/Title";
 import { Menu } from "./Home/Menu";
 import { Profile } from "./Home/Profile";
@@ -14,16 +15,12 @@ export const Home = () => (
     <main className="py-8 md:py-24">
       <nav>
         <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <Menu link="/blog" icon={solid("blog")} content="Blog" />
-          <Menu link="/slides" icon={solid("images")} content="Slides" />
-          <Menu link="https://github.com/ybiquitous" icon={brands("github")} content="GitHub" />
-          <Menu link="https://twitter.com/ybiquitous" icon={brands("twitter")} content="Twitter" />
-          <Menu link="https://www.npmjs.com/~ybiquitous" icon={brands("npm")} content="npm" />
-          <Menu
-            link="https://rubygems.org/profiles/ybiquitous"
-            icon={solid("gem")}
-            content="RubyGems"
-          />
+          <Menu link="/blog" icon={faBlog} content="Blog" />
+          <Menu link="/slides" icon={faImages} content="Slides" />
+          <Menu link="https://github.com/ybiquitous" icon={faGithub} content="GitHub" />
+          <Menu link="https://twitter.com/ybiquitous" icon={faTwitter} content="Twitter" />
+          <Menu link="https://www.npmjs.com/~ybiquitous" icon={faNpm} content="npm" />
+          <Menu link="https://rubygems.org/profiles/ybiquitous" icon={faGem} content="RubyGems" />
         </div>
       </nav>
     </main>

--- a/src/pages/Home/Profile.jsx
+++ b/src/pages/Home/Profile.jsx
@@ -1,4 +1,4 @@
-import { solid } from "@fortawesome/fontawesome-svg-core/import.macro";
+import { faLocationDot } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export const Profile = () => (
@@ -19,7 +19,7 @@ export const Profile = () => (
       <div className="my-text-secondary sm:text-xl">@ybiquitous</div>
       <p className="mt-4 italic">I’m a Web Programmer. I love Emacs, JavaScript, CSS, and Ruby.</p>
       <small className="my-text-secondary mt-1 inline-flex items-center gap-1">
-        <FontAwesomeIcon icon={solid("location-dot")} className="mr-1" />
+        <FontAwesomeIcon icon={faLocationDot} className="mr-1" />
         Tokyo, Japan
       </small>
     </div>


### PR DESCRIPTION
This method has been deprecated:

> In version 6 we introduced a Babel Macro that while useful is becoming more difficult
> to configure and isn’t an option for folks who aren’t using Babel.

Ref https://docs.fontawesome.com/web/use-with/react/add-icons#what-about-dynamic-importing-deprecated

<!--

Checklist:

    * Simplfy the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
