### PR TITLE
Stop building CSS Nesting

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,7 +3,6 @@ import process from "node:process";
 import autoprefixer from "autoprefixer";
 import cssnano from "cssnano";
 import tailwindcss from "tailwindcss";
-import tailwindcssNesting from "tailwindcss/nesting/index.js";
 /* eslint-enable import/no-extraneous-dependencies */
 
 const PRODUCTION = process.env["NODE_ENV"] === "production";
@@ -11,7 +10,6 @@ const PRODUCTION = process.env["NODE_ENV"] === "production";
 const config = {
   plugins: [
     // The order is important.
-    tailwindcssNesting,
     tailwindcss,
     autoprefixer,
     PRODUCTION ? cssnano : undefined,


### PR DESCRIPTION
Today (2025), CSS Nesting has been accepted as Baseline 2023.
Ref https://caniuse.com/css-nesting

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/ccd27893-9782-4fd4-b400-741e69faaa1e" />

<!--

Checklist:

    * Simplify the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
