### PR TITLE
Fix code block background color on blog

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -64,7 +64,9 @@
 
   .markdown {
     & .hljs {
-      @apply !p-0 !text-current;
+      @apply !p-0;
+      color: currentcolor !important;
+      background: inherit !important;
     }
 
     & > h1,

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,7 @@
   }
 
   .markdown {
+    /* NOTE: This overrides the highlight.js theme. */
     & .hljs {
       @apply !p-0;
 

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,7 @@
   .markdown {
     & .hljs {
       @apply !p-0;
+
       color: currentcolor !important;
       background: inherit !important;
     }


### PR DESCRIPTION
This fixes the code block's background color on blog posts.
This bug was introduced in PR #1719, which was the Tailwind CSS upgrade to v4.

| Before | After |
|--------|--------|
| <img width="835" alt="image" src="https://github.com/user-attachments/assets/467eb1f9-a91f-4705-af57-b3946e8ccc82" /> | <img width="839" alt="image" src="https://github.com/user-attachments/assets/eaee3df1-577e-479c-8b15-8c29e5b59e1a" /> | 

https://ybiquitous.me/blog/2019/type-compatibility-in-typescript

<!--

Checklist:

    * Simplify the title.
    * Leave a reason in the body.
    * Add proper labels like "bug" or "blog" etc. See https://github.com/ybiquitous/homepage/labels

-->
